### PR TITLE
Added checks for session starting

### DIFF
--- a/bioserv1/www/login.php
+++ b/bioserv1/www/login.php
@@ -1,5 +1,7 @@
 <?php
-	session_start();
+	if (session_status() === PHP_SESSION_NONE) {
+		session_start();
+	}
 	include('header.php');
 ?>
 

--- a/bioserv1/www/login_form.php
+++ b/bioserv1/www/login_form.php
@@ -1,5 +1,7 @@
 <?php
-	session_start();
+	if (session_status() === PHP_SESSION_NONE) {
+		session_start();
+	}
 	
 	require_once('db_cred.php');
 

--- a/bioserv2/www/login.php
+++ b/bioserv2/www/login.php
@@ -1,5 +1,7 @@
 <?php
-	session_start();
+	if (session_status() === PHP_SESSION_NONE) {
+		session_start();
+	}
 	include('header.php');
 ?>
 

--- a/bioserv2/www/login_form.php
+++ b/bioserv2/www/login_form.php
@@ -1,5 +1,7 @@
 <?php
-	session_start();
+	if (session_status() === PHP_SESSION_NONE) {
+		session_start();
+	}
 	
 	require_once('db_cred.php');
 


### PR DESCRIPTION
It's good practice to check if a session already exists before starting a new one, as trying to start a new one when one already exists could trigger warnings and lead to cookie issues.