### PR TITLE
Improve reproduction

### DIFF
--- a/docker/apache.Dockerfile
+++ b/docker/apache.Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /var/www
 RUN touch /var/www/index.html
 #better pass to conf.d
 COPY ./docker/vars/apache/httpd.conf /opt/apache/conf/httpd.conf
-COPY ./docker/vars/apache/start.sh /var/www/
+COPY --chmod=754 ./docker/vars/apache/start.sh /var/www/
 COPY --chown=www-data:www-data ./docker/vars/php/www /var/www
 COPY --chown=www-data:www-data ./bioserv1/www /var/www/dnas/00000002
 COPY --chown=www-data:www-data ./bioserv2/www /var/www/dnas/00000010

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -9,7 +9,7 @@ RUN wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j_8.0.3
     && dpkg --install mysql-connector-j_8.0.32-1debian11_all.deb
 
 COPY --chown=www-data:www-data $SERVER_PATH /var/www/bioserver
-COPY --chown=www-data:www-data $RUN_FILE_PATH /var/www/run.sh
+COPY --chown=www-data:www-data --chmod=754 $RUN_FILE_PATH /var/www/run.sh
 
 WORKDIR /var/www
 

--- a/docker/vars/apache/httpd.conf
+++ b/docker/vars/apache/httpd.conf
@@ -500,6 +500,8 @@ Include conf/extra/proxy-html.conf
 Listen 443
 <IfModule ssl_module>
 <VirtualHost *:443>
+        # Ensure Content-Length from php isn't discarded
+        SetEnv ap_trust_cgilike_cl 1
         SSLEngine on
         # nail it to the securest cipher PS2 understands DHE-RSA-DES-CBC3-SHA
         # check this with openssl
@@ -573,6 +575,8 @@ Listen 443
 </VirtualHost>
 
 <VirtualHost *:443>
+        # Ensure Content-Length from php isn't discarded
+        SetEnv ap_trust_cgilike_cl 1
         SSLEngine on
         # nail it to the securest cipher PS2 understands DHE-RSA-DES-CBC3-SHA
         # check this with openssl
@@ -632,6 +636,8 @@ Listen 443
         downgrade-1.0 force-response-1.0
 </VirtualHost>
 <VirtualHost *:443>
+        # Ensure Content-Length from php isn't discarded
+        SetEnv ap_trust_cgilike_cl 1
         SSLEngine on
         # nail it to the securest cipher PS2 understands DHE-RSA-DES-CBC3-SHA
         # check this with openssl


### PR DESCRIPTION
- `chmod` run scripts to be executable in case the permissions aren't set on the source files
- Fix httpd discarding Content-Length from DNAS connect.php

Unsure if the Content-Length issue is some environment thing or caused by the update to 2.4.61. The docs say the setting exist since 2.4.59 which was the previous version used.